### PR TITLE
Fix for sending messages issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,15 @@
 # PR Details
 
 <!--- Provide a general summary of your changes in the Title above -->
+Fix bugs:
+ - r.findImpl is not a function
+ - ready event doesn't work
 
 ## Description
 
+It was not possible to send messages to new conversations by accounts whatsapp business returned this error: "r.findImpl is not a function"
+
+The ready event was not working making it impossible to send messages
 <!--- Describe your changes in detail -->
 
 ## Related Issue
@@ -26,7 +32,7 @@
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 
 - [ ] Dependency change
-- [ ] Bug fix (non-breaking change which fixes an issue)
+- [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
@@ -34,8 +40,8 @@
 
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 
-- [ ] My code follows the code style of this project.
-- [ ] I have updated the documentation accordingly (index.d.ts).
+- [x] My code follows the code style of this project.
+- [x] I have updated the documentation accordingly (index.d.ts).
 
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,9 @@
 # PR Details
 
 <!--- Provide a general summary of your changes in the Title above -->
-Fix bugs:
- - r.findImpl is not a function
- - ready event doesn't work
 
 ## Description
 
-It was not possible to send messages to new conversations by accounts whatsapp business returned this error: "r.findImpl is not a function"
-
-The ready event was not working making it impossible to send messages
 <!--- Describe your changes in detail -->
 
 ## Related Issue
@@ -32,7 +26,7 @@ The ready event was not working making it impossible to send messages
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 
 - [ ] Dependency change
-- [x] Bug fix (non-breaking change which fixes an issue)
+- [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
@@ -40,8 +34,8 @@ The ready event was not working making it impossible to send messages
 
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 
-- [x] My code follows the code style of this project.
-- [x] I have updated the documentation accordingly (index.d.ts).
+- [ ] My code follows the code style of this project.
+- [ ] I have updated the documentation accordingly (index.d.ts).
 
 
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -154,7 +154,7 @@ class Client extends EventEmitter {
             }
         );
 
-        const INTRO_IMG_SELECTOR = '[data-testid="intro-md-beta-logo-dark"], [data-testid="intro-md-beta-logo-light"], [data-asset-intro-image-light="true"], [data-asset-intro-image-dark="true"]';
+        const INTRO_IMG_SELECTOR = "[data-icon='chat']";
         const INTRO_QRCODE_SELECTOR = 'div[data-ref] canvas';
 
         // Checks which selector appears first

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -80,6 +80,13 @@ exports.ExposeStore = (moduleRaidStr) => {
         };
     }
 
+    // type error fpeError: r.findImpl is not a function solution
+    if (window.mR.findModule('ChatCollection')[0] && window.mR.findModule('ChatCollection')[0].ChatCollection) {
+        if (typeof window.mR.findModule('ChatCollection')[0].ChatCollection.findImpl === 'undefined' && typeof window.mR.findModule('ChatCollection')[0].ChatCollection._find != 'undefined') {
+            window.mR.findModule('ChatCollection')[0].ChatCollection.findImpl = window.mR.findModule('ChatCollection')[0].ChatCollection._find;
+        }
+    }
+
     // TODO remove these once everybody has been updated to WWebJS with legacy sessions removed
     const _linkPreview = window.mR.findModule('queryLinkPreview');
     if (_linkPreview && _linkPreview[0] && _linkPreview[0].default) {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fix bugs:
 - r.findImpl is not a function
 - ready event doesn't work

## Description

It was not possible to send messages to new conversations by accounts whatsapp business returned this error: "r.findImpl is not a function"

The ready event was not working making it impossible to send messages
<!--- Describe your changes in detail -->

## Motivation and Context

without these corrections it is not possible to send messages
<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

I simulated the error connecting with a whatsapp business account and right after the correction the error did not happen anymore

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



